### PR TITLE
fix  Warning: Undefined array key 0 in src\addons\yform_usability\lib…

### DIFF
--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -79,7 +79,7 @@ class Utils
         }
 
         return [
-            'current_label' => $options[$currentValue],
+            'current_label' => $options[$currentValue] ?? "",
             'intern_status' => $istatus,
             'toggle_value'  => $nvalue,
             'element'       => $element,


### PR DESCRIPTION
…\Utils.php on line 64

Das Szenario kommt bspw. dann, wenn ein Datensatz dupliziert wurde, mit einem bspw. leeren Status, sodass es keinen index `$options[$currentValue]` gab.